### PR TITLE
make build-task depend on shadowjar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,3 +79,7 @@ tasks.withType(JavaCompile) {
 shadowJar {
     relocate ('net.kyori', 'libs.kyori')
 }
+tasks.register("delete", Delete).get().delete("build/libs/"+project.name+"-"+project.version+".jar")
+tasks.named("build").get().dependsOn("shadowJar").finalizedBy("delete").doLast {
+    println("Deleting: "+ "build/libs/"+project.name+"-"+project.version+".jar")
+}


### PR DESCRIPTION
Not sure u want this but just makes buildtask run shadowjar
also deletes the file generated by build