### PR TITLE
Removed a useless folder in ItemsAdder/contents

### DIFF
--- a/src/main/java/net/momirealms/customnameplates/manager/ResourceManager.java
+++ b/src/main/java/net/momirealms/customnameplates/manager/ResourceManager.java
@@ -299,7 +299,7 @@ public class ResourceManager {
     private void hookCopy(File resourcePack_folder) {
         if (ConfigManager.itemsAdderHook){
             try {
-                FileUtils.copyDirectory(resourcePack_folder, new File(Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("ItemsAdder")).getDataFolder() + File.separator + "contents" + File.separator + "contents/nameplates" + File.separator + "resourcepack") );
+                FileUtils.copyDirectory(resourcePack_folder, new File(Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("ItemsAdder")).getDataFolder() + File.separator + "contents" + File.separator + "nameplates" + File.separator + "resourcepack") );
             }
             catch (IOException e){
                 e.printStackTrace();


### PR DESCRIPTION
Before this fix, the plugin created an extra folder. It looked like this: ItemsAdder/contents/contents/nameplates. Because of this, Itemsadder did not read the folder and the Resource Pack did not work.