### PR TITLE
Fix channel-mode

### DIFF
--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/CarbonChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/CarbonChatProvider.java
@@ -95,10 +95,8 @@ public class CarbonChatProvider extends AbstractChatProvider {
             return false;
         }
         ChatChannel selectedChannel = cPlayer.selectedChannel();
-        if (selectedChannel == null) {
-            return false;
-        }
-        Object key = getChannelKey(selectedChannel);
+        ChatChannel currentChannel = selectedChannel != null ? selectedChannel : api.channelRegistry().defaultChannel();
+        Object key = getChannelKey(currentChannel);
         String str = ReflectionUtils.getKeyAsString(key);
         return str.equals(channelID);
     }

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/util/ReflectionUtils.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/util/ReflectionUtils.java
@@ -135,7 +135,7 @@ public class ReflectionUtils {
 
     public static Object getKerFromString(String key) {
         try {
-            return keyFromStringMethod.invoke(key);
+            return keyFromStringMethod.invoke(null, key);
         } catch (InvocationTargetException | IllegalAccessException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
We had issues with both config options `CAN_JOIN` and `JOINED`.

`JOINED` issue was Carbon specific, the commit details specifics.

`CAN_JOIN` did not work because the `#invoke` was not being passed arguments.
This error was not being emitted, which may be why it went unnoticed.