### PR TITLE
[Feature] Support Ignoring for Chat Bubbles

### DIFF
--- a/api/src/main/java/net/momirealms/customnameplates/api/mechanic/bubble/provider/AbstractChatProvider.java
+++ b/api/src/main/java/net/momirealms/customnameplates/api/mechanic/bubble/provider/AbstractChatProvider.java
@@ -36,4 +36,6 @@ public abstract class AbstractChatProvider implements Listener {
     public abstract boolean hasJoinedChannel(Player player, String channelID);
 
     public abstract boolean canJoinChannel(Player player, String channelID);
+
+    public abstract boolean isIgnoring(Player sender, Player receiver);
 }

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/BubbleManagerImpl.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/BubbleManagerImpl.java
@@ -350,6 +350,9 @@ public class BubbleManagerImpl implements BubbleManager, Listener {
         StaticTextEntity entity = tagEntity.addTag(StaticTextTagSetting.builder()
                 .leaveRule((p, e) -> true)
                 .comeRule((p, e) -> {
+                    if ((e instanceof Player) && chatProvider.isIgnoring(p, (Player) e)) {
+                        return false;
+                    }
                     switch (channelMode) {
                         case ALL -> {
                             return true;

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/AsyncChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/AsyncChatProvider.java
@@ -52,6 +52,11 @@ public class AsyncChatProvider extends AbstractChatProvider {
         return true;
     }
 
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        return false;
+    }
+
     // This event is not async sometimes
     @EventHandler (ignoreCancelled = true)
     public void onChat(AsyncPlayerChatEvent event) {

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/CarbonChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/CarbonChatProvider.java
@@ -30,9 +30,11 @@ import net.momirealms.customnameplates.api.util.LogUtils;
 import net.momirealms.customnameplates.paper.util.ReflectionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.UUID;
 
 public class CarbonChatProvider extends AbstractChatProvider {
 
@@ -123,6 +125,28 @@ public class CarbonChatProvider extends AbstractChatProvider {
             return true;
         }
         return player.hasPermission(perm);
+    }
+
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        CarbonPlayer sPlayer = carbonPlayer(sender.getUniqueId());
+        CarbonPlayer rPlayer = carbonPlayer(receiver.getUniqueId());
+        if (sPlayer == null || rPlayer == null) {
+            return false;
+        }
+        return sPlayer.ignoring(rPlayer.uuid());
+    }
+
+    @Nullable
+    private CarbonPlayer carbonPlayer(UUID uuid) {
+        CarbonPlayer carbonPlayer = null;
+        for (CarbonPlayer cPlayer : api.server().players()) {
+            if (cPlayer.uuid().equals(uuid)) {
+                carbonPlayer = cPlayer;
+                break;
+            }
+        }
+        return carbonPlayer;
     }
 
     private Object getChannelKey(ChatChannel channel) {

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/HuskChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/HuskChatProvider.java
@@ -69,6 +69,11 @@ public class HuskChatProvider extends AbstractChatProvider {
         return player.hasPermission(receivePerm);
     }
 
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        return false;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onHuskChat(ChatMessageEvent event) {
         String channel = event.getChannelId();

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/PaperAsyncChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/PaperAsyncChatProvider.java
@@ -63,6 +63,11 @@ public class PaperAsyncChatProvider extends AbstractChatProvider {
         return true;
     }
 
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        return false;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onChat(AsyncChatEvent event) {
         Object component = getComponentFromEvent(event);

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/TrChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/TrChatProvider.java
@@ -71,6 +71,11 @@ public class TrChatProvider extends AbstractChatProvider {
         }
     }
 
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        return false;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onTrChat(TrChatEvent event) {
         if (!event.getForward()) return;

--- a/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/VentureChatProvider.java
+++ b/paper/src/main/java/net/momirealms/customnameplates/paper/mechanic/bubble/provider/VentureChatProvider.java
@@ -65,6 +65,11 @@ public class VentureChatProvider extends AbstractChatProvider {
         return true;
     }
 
+    @Override
+    public boolean isIgnoring(Player sender, Player receiver) {
+        return false;
+    }
+
     @EventHandler (ignoreCancelled = true)
     public void onVentureChat(VentureChatEvent event) {
         String channelName = event.getChannel().getName();


### PR DESCRIPTION
Allows for plugins that allow for ignoring (eg. `/ignore`) to also ignore chat bubbles.

Carbon was given special attention for this PR, but supported providers will maintain prior behavior.

Because this adds and implements a method in the API, **this is a breaking change for any 3rd party plugins (providers) that hook into this.**

This is **not** an issue for the providers currently being supported, as mentioned before, they will maintain their existing behavior.

For 3rd party providers to use this method, they simply should provide `false` to maintain existing behavior, or implement their own ignore system.